### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/io.github.idevecore.Valuta.appdata.xml.in.in
+++ b/data/io.github.idevecore.Valuta.appdata.xml.in.in
@@ -15,7 +15,7 @@
   <url type="donation">https://ko-fi.com/idevecore</url>
   <releases>
     <release version="1.2.0" date="2024-01-20">
-      <description translatable="no">
+      <description translate="no">
         <p>In this version we bring:</p>
         <ul>
           <li>New ui;</li>
@@ -27,7 +27,7 @@
   </releases>
   <releases>
     <release version="1.1.0" date="2023-08-14">
-      <description translatable="no">
+      <description translate="no">
         <p>In this version we bring:</p>
         <ul>
           <li>New ui;</li>
@@ -44,7 +44,7 @@
 
   <releases>
     <release version="1.0.0" date="2023-07-14">
-      <description translatable="no">
+      <description translate="no">
         <p>Currency Converter 1.0.0: Application launch</p>
       </description>
     </release>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: `https://github.com/ximion/appstream/issues/623`

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html