### PR TITLE
build: replace appstream-utils with appstreamcli

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -36,10 +36,10 @@ appstream_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'appdata')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util,
-    args: ['validate-relax', appstream_file.full_path()]
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli,
+    args: ['validate', appstream_file.full_path()]
   )
 endif
 


### PR DESCRIPTION
`appstream-utils` did not allow the tests to pass, because of the images padding. Flathub has changed the utility for checking appdata files. 

Link: https://github.com/flathub-infra/flatpak-builder-lint/commit/bbfc701d87c53d6336febf6d4e1121dad424f367