### PR TITLE
build: Install metainfo file to correct location

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -33,7 +33,7 @@ appstream_file = i18n.merge_file(
   output: '@0@.appdata.xml'.format(application_id),
   po_dir: '../po',
   install: true,
-  install_dir: join_paths(get_option('datadir'), 'appdata')
+  install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
 appstream_util = find_program('appstream-util', required: false)


### PR DESCRIPTION
Appdata files used to be installed to `/usr/share/appdata`. However, this location has been changed to `/usr/share/metainfo` in recent versions of the AppStream specification.