### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/io.github.idevecore.Valuta.desktop.in.in
+++ b/data/io.github.idevecore.Valuta.desktop.in.in
@@ -10,5 +10,6 @@ Type=Application
 Keywords=Valuta;Converter;Currency;ExchangeRate;
 Categories=Utility;GTK;GNOME;
 StartupNotify=true
+DBusActivatable=true
 X-Purism-FormFactor=Workstation;Mobile;
 X-GNOME-SingleWindow=true

--- a/data/io.github.idevecore.Valuta.service.in
+++ b/data/io.github.idevecore.Valuta.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=@app-id@
+Exec=@bindir@/valuta --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -61,4 +61,16 @@ if compile_schemas.found()
        args: ['--strict', '--dry-run', meson.current_source_dir()])
 endif
 
+# ===== Install D-Bus service file =====
+service_conf = configuration_data()
+service_conf.set('app-id', application_id)
+service_conf.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
+configure_file(
+  input: '@0@.service.in'.format(base_id),
+  output: '@0@.service'.format(application_id),
+  configuration: service_conf,
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'dbus-1/services')
+)
+
 subdir('icons')


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html